### PR TITLE
update lamp version to v20211121

### DIFF
--- a/apps/web-vm-example.py
+++ b/apps/web-vm-example.py
@@ -53,7 +53,7 @@ def GenerateConfig(context):
                         'boot': True,
                         'autoDelete': True,
                         'initializeParams': {
-                            'sourceImage': 'https://www.googleapis.com/compute/v1/projects/click-to-deploy-images/global/images/lamp-v20190909'
+                            'sourceImage': 'https://www.googleapis.com/compute/v1/projects/click-to-deploy-images/global/images/lamp-v20211121'
                         }
                     }],
                     'metadata': {


### PR DESCRIPTION
Deployment manager is looking for LAMP version 20190909 which no longer exists. Updated the deployment manager config to reference lamp-20211121 and it works without errors.